### PR TITLE
show ExcludePathChecker to allow custom excluding

### DIFF
--- a/packages/string_literal_finder/lib/string_literal_finder.dart
+++ b/packages/string_literal_finder/lib/string_literal_finder.dart
@@ -4,4 +4,4 @@ library;
 
 export 'src/plugin.dart';
 export 'src/string_literal_finder.dart'
-    show StringLiteralFinder, FoundStringLiteral;
+    show StringLiteralFinder, FoundStringLiteral,ExcludePathChecker;


### PR DESCRIPTION
#4 
show ExcludePathChecker to allow custom excluding to use the package as dependency for your own project.